### PR TITLE
[eunice.shin54] comments 도메인 pydantic schema 작성

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ async def create_post(post: dict):
 
 # post list I wrote
 @app.get("/posts/me")
-async def get_posts_mine(page: int = 1):
+async def get_posts_mine(page: Page):
     pass
 
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, Depends
 
-from schemas.commons import UserId, PostId, CommentId
+from schemas.commons import UserId, PostId, CommentId, Page
 from schemas.post import ListPostsQuery
 
 app = FastAPI()
@@ -10,7 +10,7 @@ app = FastAPI()
 
 # signup
 @app.post("/users")
-async def create_user(user: dict):
+async def create_user(user: dict):`
     pass
 
 
@@ -89,7 +89,7 @@ async def delete_post(post_id: PostId):
 
 # List all comments for a post
 @app.get("/posts/{post_id}/comments")
-async def get_comments(post_id: PostId, page: int = 1):
+async def get_comments(post_id: PostId, page: Page):
     pass
 
 
@@ -113,7 +113,7 @@ async def delete_comment(post_id: PostId, comment_id: CommentId):
 
 # comment list I wrote
 @app.get("/comments/me")
-async def get_comments_mine(page: int = 1):
+async def get_comments_mine(page: Page):
     pass
 
 
@@ -139,5 +139,5 @@ async def get_likes_status(post_id: PostId):
 
 # post list I liked
 @app.get("/posts/liked")
-async def get_posts_liked(page: int = 1):
+async def get_posts_liked(page: Page):
     pass

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
 
-from schemas.commons import UserId, PostId
+from schemas.commons import UserId, PostId, CommentId
+from schemas.post import ListPostsQuery
 
 app = FastAPI()
 
@@ -50,13 +51,9 @@ async def get_specific_user(user_id: UserId):
 
 # List, search, sort posts
 @app.get("/posts")
-async def get_posts(
-        page: int = 1,
-        q: str | None = None,
-        sort: str = "created_at",
-        order: str = "desc"
-):
+async def get_posts(query: ListPostsQuery = Depends()):
     pass
+
 
 # post new post
 @app.post("/posts")
@@ -101,14 +98,16 @@ async def get_comments(post_id: PostId, page: int = 1):
 async def post_comment(post_id: PostId):
     pass
 
+
 # edit comment
 @app.patch("/posts/{post_id}/comments/{comment_id}")
-async def update_comment(post_id: PostId, comment_id: int):
+async def update_comment(post_id: PostId, comment_id: CommentId):
     pass
+
 
 # delete comment
 @app.delete("/posts/{post_id}/comments/{comment_id}")
-async def delete_comment(post_id: PostId, comment_id: int):
+async def delete_comment(post_id: PostId, comment_id: CommentId):
     pass
 
 
@@ -125,15 +124,18 @@ async def get_comments_mine(page: int = 1):
 async def post_like(post_id: PostId):
     pass
 
+
 # delete like
 @app.delete("/posts/{post_id}/likes")
 async def delete_like(post_id: PostId):
     pass
 
+
 # check like status
 @app.get("/posts/{post_id}/likes")
 async def get_likes_status(post_id: PostId):
     pass
+
 
 # post list I liked
 @app.get("/posts/liked")

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ app = FastAPI()
 
 # signup
 @app.post("/users")
-async def create_user(user: dict):`
+async def create_user(user: dict):
     pass
 
 

--- a/schemas/comment.py
+++ b/schemas/comment.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+from pydantic import BaseModel, model_validator
+
+from schemas.commons import Content, CommentId, Pagination, PostId, UserId
+
+
+class CommentCreateRequest(BaseModel):
+    content: Content
+
+
+class CommentBase(BaseModel):
+    """댓글 생성/조회에서 공통으로 쓰는 필드"""
+    id: CommentId
+    post_id: PostId
+    author: UserId
+    content: Content
+    created_at: datetime
+
+
+class CommentUpdateRequest(BaseModel):
+    content: Content | None = None
+
+    @model_validator(mode="after")
+    def at_least_one_field(self):
+        if self.content is None:
+            raise ValueError("수정할 필드가 없습니다.")
+        return self
+
+
+class CommentUpdateResponse(CommentBase):
+    updated_at: datetime
+
+
+class CommentListResponse(BaseModel):
+    data: list[CommentBase]
+    pagination: Pagination

--- a/schemas/comment.py
+++ b/schemas/comment.py
@@ -19,13 +19,7 @@ class CommentBase(BaseModel):
 
 
 class CommentUpdateRequest(BaseModel):
-    content: Content | None = None
-
-    @model_validator(mode="after")
-    def at_least_one_field(self):
-        if self.content is None:
-            raise ValueError("수정할 필드가 없습니다.")
-        return self
+    content: Content
 
 
 class CommentUpdateResponse(CommentBase):

--- a/schemas/comment.py
+++ b/schemas/comment.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel
 
 from schemas.commons import Content, CommentId, Pagination, PostId, UserId
 

--- a/schemas/commons.py
+++ b/schemas/commons.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from pydantic import Field, BaseModel
+from pydantic import Field, BaseModel, StringConstraints
 
 UserId = Annotated[
     str,
@@ -20,9 +20,23 @@ PostId = Annotated[
     ),
 ]
 
+CommentId = Annotated[
+    str,
+    Field(
+        pattern=r"^comment_\d+$",
+        description="댓글 ID",
+        examples=["comment_123"],
+    )
+]
+
 Page = Annotated[
     int,
     Field(default=1, ge=1, le=10000, description="조회할 페이지 번호"),
+]
+
+Content = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=2000),
 ]
 
 

--- a/schemas/post.py
+++ b/schemas/post.py
@@ -3,19 +3,15 @@ from typing import Annotated, Literal
 
 from pydantic import StringConstraints, BaseModel, Field, model_validator
 
-from schemas.commons import PostId, UserId, Pagination, Page
+from schemas.commons import PostId, UserId, Pagination, Page, Content
 
 Title = Annotated[
     str,
     StringConstraints(strip_whitespace=True, min_length=1, max_length=50),
 ]
 
-Content = Annotated[
-    str,
-    StringConstraints(strip_whitespace=True, min_length=1, max_length=2000),
-]
-
 Count = Annotated[int, Field(ge=0)]
+
 
 class PostListItem(BaseModel):
     id: PostId
@@ -61,5 +57,3 @@ class PostUpdateRequest(BaseModel):
         if self.title is None and self.content is None:
             raise ValueError("수정할 필드가 없습니다.")
         return self
-
-

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -31,8 +31,6 @@ class UserCreateRequest(BaseModel):
 
 
 class UserCreateResponse(BaseModel):
-    model_config = {"from_attributes": True}
-
     id: int
     nickname: Nickname
     email: EmailStr
@@ -45,14 +43,10 @@ class UserLoginRequest(BaseModel):
 
 
 class UserLoginResponse(BaseModel):
-    model_config = {"from_attributes": True}
-
     access_token: str
 
 
 class UserMyProfile(BaseModel):
-    model_config = {"from_attributes": True}
-
     id: int
     email: EmailStr
     nickname: Nickname
@@ -72,8 +66,6 @@ class UserUpdateRequest(BaseModel):
 
 
 class UserProfile(BaseModel):
-    model_config = {"from_attributes": True}
-
     id: int
     nickname: Nickname
     profile_img: str | None = None

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -9,9 +9,6 @@ Password = Annotated[
         pattern=r"^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[!\"#$%&'()*+,\-./:;<=>?@\[₩\]\^_`{|}~])[A-Za-z\d!\"#$%&'()*+,\-./:;<=>?@\[₩\]\^_`{|}~]+$",
         min_length=8,
         max_length=16,
-        error_message=(
-            "비밀번호는 8~16자이며 영문 대소문자, 숫자, 허용된 특수문자 1개 이상을 포함해야 합니다"
-        ),
     ),
 ]
 
@@ -22,7 +19,6 @@ Nickname = Annotated[
         min_length=1,
         max_length=10,
         pattern=r"^[A-Za-z0-9]+$",
-        error_message="닉네임은 1~10자의 영문 대소문자 및 숫자만 사용할 수 있습니다",
     ),
 ]
 
@@ -71,7 +67,7 @@ class UserUpdateRequest(BaseModel):
     @model_validator(mode='after')
     def check_at_least_one_field(self):
         if self.nickname is None and self.profile_img is None:
-            raise ValueError("최소 하나의 필드는 입력해야 합니다")
+            raise ValueError("최소 하나의 필드는 입력 해야 합니다")
         return self
 
 


### PR DESCRIPTION
## 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- comments 도메인 Pydantic 스키마 추가/정리
  - CommentCreateRequest, CommentBase, CommentUpdateRequest, CommentUpdateResponse, CommentListResponse(및 /comments/me 재사용 가능)
- 문자열 제약 타입 Content를 schemas/commons.py로 이동해 공통 타입으로 통일
- 댓글 수정(PATCH) 요청에서 빈 바디 방지 로직 추가 (content=None이면 에러)
- 댓글 목록 조회/내가 쓴 댓글 목록 응답에서 pagination(page, total) 포함해 API 응답 형태 고정

## 변경 이유
<!-- 왜 이 변경이 필요한지 설명해주세요 -->
- FastAPI에서 요청, 응답 검증 및 Swagger 문서 자동화를 위해 엔드포인트별 스키마가 필요
- 댓글, 게시글 등 여러 도메인에서 동일한 문자열 제약을 공통 타입으로 관리해 중복을 줄이고 일관성을 확보
- PATCH 요청에서 수정할 필드가 없는 요청을 조기에 차단해 API 사용 실수를 줄이기 위함
- 목록 조회 응답에서 data + pagination 구조를 문서 스펙과 동일하게 맞추기 위함


## 체크리스트
- [x] Request/Response 예시가 API Docs와 일치하는지 확인했습니다 (필드명/타입/optional)
- [x] Pagination 응답 형식이 기존 엔드포인트들과 일관적인지 확인했습니다 (data + pagination)
- [x] PATCH 요청에서 빈 바디/빈 필드 요청이 400으로 처리되는지 확인했습니다
- [x] 공통 타입(Title, Content, Count, Pagination 등) 이동/변경으로 인한 import 깨짐이 없는지 확인했습니다



## 🚨 Breaking Changes
<!-- 
Breaking Changes란? 
기존에 동작하던 코드나 API가 이번 변경으로 인해 더 이상 작동하지 않게 되는 변경사항을 의미합니다.
예: 함수 이름 변경, 파라미터 변경, API 엔드포인트 변경 등
해당사항이 없다면 체크박스를 해제된 상태로 두시면 됩니다.
-->
- [x] 이 PR은 Breaking Changes를 포함하지 않습니다
<!-- Breaking Changes가 있다면 아래에 구체적으로 설명해주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 댓글 관련 요청/응답 형식 추가 및 댓글 목록 응답 제공

* **개선 사항**
  * 페이지네이션 응답에 전체 페이지 수(total) 추가
  * 콘텐츠 입력 유효성 강화(공백 정리, 길이 제한 1–2000자)
  * 게시물 목록 조회의 쿼리 입력을 묶어 처리해 필터/정렬 입력 단순화

* **수정**
  * 댓글 식별자 및 일부 입력 검증이 더 엄격해짐
  * 일부 인증/검증 오류 메시지 표현 변경

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->