### PR TITLE
[eunice.shin54] likes 도메인 pydantic schema 작성

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ async def create_post(post: dict):
 
 # post list I wrote
 @app.get("/posts/me")
-async def get_posts_mine(page: int = 1):
+async def get_posts_mine(page: Page):
     pass
 
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, Depends
 
-from schemas.commons import UserId, PostId, CommentId
+from schemas.commons import UserId, PostId, CommentId, Page
 from schemas.post import ListPostsQuery
 
 app = FastAPI()
@@ -10,7 +10,7 @@ app = FastAPI()
 
 # signup
 @app.post("/users")
-async def create_user(user: dict):
+async def create_user(user: dict):`
     pass
 
 
@@ -89,7 +89,7 @@ async def delete_post(post_id: PostId):
 
 # List all comments for a post
 @app.get("/posts/{post_id}/comments")
-async def get_comments(post_id: PostId, page: int = 1):
+async def get_comments(post_id: PostId, page: Page):
     pass
 
 
@@ -113,7 +113,7 @@ async def delete_comment(post_id: PostId, comment_id: CommentId):
 
 # comment list I wrote
 @app.get("/comments/me")
-async def get_comments_mine(page: int = 1):
+async def get_comments_mine(page: Page):
     pass
 
 
@@ -139,5 +139,5 @@ async def get_likes_status(post_id: PostId):
 
 # post list I liked
 @app.get("/posts/liked")
-async def get_posts_liked(page: int = 1):
+async def get_posts_liked(page: Page):
     pass

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
 
-from schemas.commons import UserId, PostId
+from schemas.commons import UserId, PostId, CommentId
+from schemas.post import ListPostsQuery
 
 app = FastAPI()
 
@@ -50,13 +51,9 @@ async def get_specific_user(user_id: UserId):
 
 # List, search, sort posts
 @app.get("/posts")
-async def get_posts(
-        page: int = 1,
-        q: str | None = None,
-        sort: str = "created_at",
-        order: str = "desc"
-):
+async def get_posts(query: ListPostsQuery = Depends()):
     pass
+
 
 # post new post
 @app.post("/posts")
@@ -101,14 +98,16 @@ async def get_comments(post_id: PostId, page: int = 1):
 async def post_comment(post_id: PostId):
     pass
 
+
 # edit comment
 @app.patch("/posts/{post_id}/comments/{comment_id}")
-async def update_comment(post_id: PostId, comment_id: int):
+async def update_comment(post_id: PostId, comment_id: CommentId):
     pass
+
 
 # delete comment
 @app.delete("/posts/{post_id}/comments/{comment_id}")
-async def delete_comment(post_id: PostId, comment_id: int):
+async def delete_comment(post_id: PostId, comment_id: CommentId):
     pass
 
 
@@ -125,15 +124,18 @@ async def get_comments_mine(page: int = 1):
 async def post_like(post_id: PostId):
     pass
 
+
 # delete like
 @app.delete("/posts/{post_id}/likes")
 async def delete_like(post_id: PostId):
     pass
 
+
 # check like status
 @app.get("/posts/{post_id}/likes")
 async def get_likes_status(post_id: PostId):
     pass
+
 
 # post list I liked
 @app.get("/posts/liked")

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ app = FastAPI()
 
 # signup
 @app.post("/users")
-async def create_user(user: dict):`
+async def create_user(user: dict):
     pass
 
 

--- a/schemas/comment.py
+++ b/schemas/comment.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+from pydantic import BaseModel, model_validator
+
+from schemas.commons import Content, CommentId, Pagination, PostId, UserId
+
+
+class CommentCreateRequest(BaseModel):
+    content: Content
+
+
+class CommentBase(BaseModel):
+    """댓글 생성/조회에서 공통으로 쓰는 필드"""
+    id: CommentId
+    post_id: PostId
+    author: UserId
+    content: Content
+    created_at: datetime
+
+
+class CommentUpdateRequest(BaseModel):
+    content: Content | None = None
+
+    @model_validator(mode="after")
+    def at_least_one_field(self):
+        if self.content is None:
+            raise ValueError("수정할 필드가 없습니다.")
+        return self
+
+
+class CommentUpdateResponse(CommentBase):
+    updated_at: datetime
+
+
+class CommentListResponse(BaseModel):
+    data: list[CommentBase]
+    pagination: Pagination

--- a/schemas/comment.py
+++ b/schemas/comment.py
@@ -19,13 +19,7 @@ class CommentBase(BaseModel):
 
 
 class CommentUpdateRequest(BaseModel):
-    content: Content | None = None
-
-    @model_validator(mode="after")
-    def at_least_one_field(self):
-        if self.content is None:
-            raise ValueError("수정할 필드가 없습니다.")
-        return self
+    content: Content
 
 
 class CommentUpdateResponse(CommentBase):

--- a/schemas/comment.py
+++ b/schemas/comment.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel
 
 from schemas.commons import Content, CommentId, Pagination, PostId, UserId
 

--- a/schemas/commons.py
+++ b/schemas/commons.py
@@ -38,6 +38,12 @@ Content = Annotated[
     str,
     StringConstraints(strip_whitespace=True, min_length=1, max_length=2000),
 ]
+Title = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=50),
+]
+
+Count = Annotated[int, Field(ge=0)]
 
 
 class Pagination(BaseModel):

--- a/schemas/commons.py
+++ b/schemas/commons.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from pydantic import Field, BaseModel
+from pydantic import Field, BaseModel, StringConstraints
 
 UserId = Annotated[
     str,
@@ -20,9 +20,23 @@ PostId = Annotated[
     ),
 ]
 
+CommentId = Annotated[
+    str,
+    Field(
+        pattern=r"^comment_\d+$",
+        description="댓글 ID",
+        examples=["comment_123"],
+    )
+]
+
 Page = Annotated[
     int,
     Field(default=1, ge=1, le=10000, description="조회할 페이지 번호"),
+]
+
+Content = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=2000),
 ]
 
 

--- a/schemas/like.py
+++ b/schemas/like.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+# - [ ]  **내가 좋아요한 게시글 목록**: 로그인한 사용자가 좋아요 누른 게시글들 조회
+from pydantic import BaseModel
+
+from schemas.commons import PostId, UserId, Pagination
+from schemas.post import Count, Title
+
+
+class LikedListItem(BaseModel):
+    post_id: PostId
+    author: UserId
+    title: Title
+    view_count: Count
+    like_cound: Count
+    created_at: datetime
+
+
+class ListPostILiked(BaseModel):
+    data: list[LikedListItem]
+    pagination: Pagination
+
+
+class LikeStatusResponse(BaseModel):
+    liked: bool
+    like_count: Count

--- a/schemas/like.py
+++ b/schemas/like.py
@@ -2,8 +2,7 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
-from schemas.commons import PostId, UserId, Pagination
-from schemas.post import Count, Title
+from schemas.commons import PostId, UserId, Pagination, Count, Title
 
 
 class LikedListItem(BaseModel):

--- a/schemas/like.py
+++ b/schemas/like.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-# - [ ]  **내가 좋아요한 게시글 목록**: 로그인한 사용자가 좋아요 누른 게시글들 조회
 from pydantic import BaseModel
 
 from schemas.commons import PostId, UserId, Pagination

--- a/schemas/like.py
+++ b/schemas/like.py
@@ -11,7 +11,7 @@ class LikedListItem(BaseModel):
     author: UserId
     title: Title
     view_count: Count
-    like_cound: Count
+    like_count: Count
     created_at: datetime
 
 

--- a/schemas/post.py
+++ b/schemas/post.py
@@ -3,19 +3,15 @@ from typing import Annotated, Literal
 
 from pydantic import StringConstraints, BaseModel, Field, model_validator
 
-from schemas.commons import PostId, UserId, Pagination, Page
+from schemas.commons import PostId, UserId, Pagination, Page, Content
 
 Title = Annotated[
     str,
     StringConstraints(strip_whitespace=True, min_length=1, max_length=50),
 ]
 
-Content = Annotated[
-    str,
-    StringConstraints(strip_whitespace=True, min_length=1, max_length=2000),
-]
-
 Count = Annotated[int, Field(ge=0)]
+
 
 class PostListItem(BaseModel):
     id: PostId
@@ -61,5 +57,3 @@ class PostUpdateRequest(BaseModel):
         if self.title is None and self.content is None:
             raise ValueError("수정할 필드가 없습니다.")
         return self
-
-

--- a/schemas/post.py
+++ b/schemas/post.py
@@ -3,14 +3,7 @@ from typing import Annotated, Literal
 
 from pydantic import StringConstraints, BaseModel, Field, model_validator
 
-from schemas.commons import PostId, UserId, Pagination, Page, Content
-
-Title = Annotated[
-    str,
-    StringConstraints(strip_whitespace=True, min_length=1, max_length=50),
-]
-
-Count = Annotated[int, Field(ge=0)]
+from schemas.commons import PostId, UserId, Pagination, Page, Content, Title, Count
 
 
 class PostListItem(BaseModel):

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -31,8 +31,6 @@ class UserCreateRequest(BaseModel):
 
 
 class UserCreateResponse(BaseModel):
-    model_config = {"from_attributes": True}
-
     id: int
     nickname: Nickname
     email: EmailStr
@@ -45,14 +43,10 @@ class UserLoginRequest(BaseModel):
 
 
 class UserLoginResponse(BaseModel):
-    model_config = {"from_attributes": True}
-
     access_token: str
 
 
 class UserMyProfile(BaseModel):
-    model_config = {"from_attributes": True}
-
     id: int
     email: EmailStr
     nickname: Nickname
@@ -72,8 +66,6 @@ class UserUpdateRequest(BaseModel):
 
 
 class UserProfile(BaseModel):
-    model_config = {"from_attributes": True}
-
     id: int
     nickname: Nickname
     profile_img: str | None = None

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -9,9 +9,6 @@ Password = Annotated[
         pattern=r"^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[!\"#$%&'()*+,\-./:;<=>?@\[₩\]\^_`{|}~])[A-Za-z\d!\"#$%&'()*+,\-./:;<=>?@\[₩\]\^_`{|}~]+$",
         min_length=8,
         max_length=16,
-        error_message=(
-            "비밀번호는 8~16자이며 영문 대소문자, 숫자, 허용된 특수문자 1개 이상을 포함해야 합니다"
-        ),
     ),
 ]
 
@@ -22,7 +19,6 @@ Nickname = Annotated[
         min_length=1,
         max_length=10,
         pattern=r"^[A-Za-z0-9]+$",
-        error_message="닉네임은 1~10자의 영문 대소문자 및 숫자만 사용할 수 있습니다",
     ),
 ]
 
@@ -71,7 +67,7 @@ class UserUpdateRequest(BaseModel):
     @model_validator(mode='after')
     def check_at_least_one_field(self):
         if self.nickname is None and self.profile_img is None:
-            raise ValueError("최소 하나의 필드는 입력해야 합니다")
+            raise ValueError("최소 하나의 필드는 입력 해야 합니다")
         return self
 
 


### PR DESCRIPTION
## 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- likes 도메인 Pydantic 스키마 추가
  - LikedListItem, ListPostILiked, LikeStatusResponse
- posts 도메인에 있던 공통 문자열 alias(Title, Content)를 schemas/commons.py로 이동
- likes 스키마에서 공통 alias를 schemas.commons에서 import 하도록 변경

## 변경 이유
<!-- 왜 이 변경이 필요한지 설명해주세요 -->
- FastAPI에서 요청, 응답 검증 및 Swagger 문서 자동화를 위해 도메인별 스키마 정의가 필요
- Title, Content는 게시글, 댓글 등 여러 도메인에서 재사용되므로 공통 타입으로 관리하는 것이 중복을 줄이고 일관성 확보
- 도메인 간 import 의존성을 줄여 스키마 구조를 더 단순하게 유지하기 위함  


## 체크리스트
- [x] Pagination 응답 형식이 기존 API들과 동일합니다 (`data`, `pagination`)
- [x] 공통 alias 이동으로 인한 import 오류가 없습니다
- [x] PATCH/상태 변경 요청에서 예외 케이스가 정상 처리됩니다
- [x] 코드 스타일 가이드를 따랐습니다


## 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- likes 응답 스키마는 Docs의 응답 형태(liked, like_count)에 맞춰 LikeStatusResponse로 정의했습니다.
- 공통 alias 이동으로 인해 기존 schemas.post에서 Title, Content를 import 하던 부분은 schemas.commons로 변경이 필요합니다.


## 🚨 Breaking Changes
<!-- 
Breaking Changes란? 
기존에 동작하던 코드나 API가 이번 변경으로 인해 더 이상 작동하지 않게 되는 변경사항을 의미합니다.
예: 함수 이름 변경, 파라미터 변경, API 엔드포인트 변경 등
해당사항이 없다면 체크박스를 해제된 상태로 두시면 됩니다.
-->
- [x] 이 PR은 Breaking Changes를 포함하지 않습니다.
<!-- Breaking Changes가 있다면 아래에 구체적으로 설명해주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 게시글 조회에서 검색·정렬·페이지네이션 처리가 더 일관되고 편리해졌습니다.
  * 댓글 관련 API의 요청/응답 타입이 강화되어 입력 검증과 페이징이 개선되었습니다.
  * 좋아요한 게시글 목록 및 좋아요 상태를 반환하는 응답 형식이 추가되었습니다.
  * 공통 데이터 타입(제목, 내용, 카운트 등)과 페이징 정보가 정비되어 검증 정확도가 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->