### PR TITLE
[eunice.shin54] users 도메인 db 연결

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,10 +15,17 @@ class Settings(BaseSettings):
     access_token_expire_minutes: int = 30
     refresh_token_expire_days: int = 7
     cookie_secure: bool = True
+
     users_file: Path = Path(__file__).resolve().parent / "data/users.json"
     posts_file: Path = Path(__file__).resolve().parent / "data/posts.json"
     comments_file: Path = Path(__file__).resolve().parent / "data/comments.json"
     likes_file: Path = Path(__file__).resolve().parent / "data/likes.json"
+
+    db_host: str
+    db_port: int
+    db_user: str
+    db_password: str
+    db_name: str
 
 
 settings = Settings()

--- a/main.py
+++ b/main.py
@@ -1,9 +1,13 @@
+import logging
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from starlette.responses import JSONResponse
 
 from routers import users, posts, comments, likes
 from utils.database import init_pool, close_pool
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -14,6 +18,23 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+
+
+@app.exception_handler(Exception)
+async def exception_handler(request: Request, exc: Exception):
+    logger.error(
+        "%s %s - %s",
+        request.method,
+        request.url.path,
+        exc,
+        exc_info=True
+    )
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal Server Error"}
+    )
+
+
 app.include_router(users.router)
 app.include_router(likes.router)
 app.include_router(posts.router)

--- a/main.py
+++ b/main.py
@@ -1,8 +1,19 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
 from routers import users, posts, comments, likes
+from utils.database import init_pool, close_pool
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await init_pool()
+    yield
+    await close_pool()
+
+
+app = FastAPI(lifespan=lifespan)
 app.include_router(users.router)
 app.include_router(likes.router)
 app.include_router(posts.router)

--- a/main.py
+++ b/main.py
@@ -5,16 +5,16 @@ from fastapi import FastAPI, Request
 from starlette.responses import JSONResponse
 
 from routers import users, posts, comments, likes
-from utils.database import init_pool, close_pool
+from utils.database import init_db_pool, close_db_pool
 
 logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    await init_pool()
+    await init_db_pool()
     yield
-    await close_pool()
+    await close_db_pool()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "bcrypt>=4.0.0,<5.0.0",
     "pyjwt>=2.10.1",
     "pydantic-settings>=2.12.0",
+    "aiomysql>=0.3.2",
 ]
 
 [project.optional-dependencies]

--- a/routers/comments.py
+++ b/routers/comments.py
@@ -13,7 +13,7 @@ from schemas.comment import (
     CommentUpdateResponse,
     CommentListResponse,
 )
-from utils.data import read_json, write_json
+from utils.database import read_json, write_json
 from utils.pagination import paginate
 
 COMMENT_PAGE_SIZE = 10

--- a/routers/likes.py
+++ b/routers/likes.py
@@ -7,7 +7,7 @@ from config import settings
 from routers.users import CurrentUserId
 from schemas.commons import PostId, Page, Pagination
 from schemas.like import LikedListItem, ListPostILiked, LikeStatusResponse
-from utils.data import read_json, write_json
+from utils.database import read_json, write_json
 from utils.pagination import paginate
 
 LIKES_PAGE_SIZE = 20

--- a/routers/posts.py
+++ b/routers/posts.py
@@ -13,7 +13,7 @@ from schemas.post import (
     PostUpdateRequest,
     ListPostsResponse,
     PostDetail)
-from utils.data import read_json, write_json
+from utils.database import read_json, write_json
 from utils.pagination import paginate
 
 PAGE_SIZE = 20

--- a/routers/users.py
+++ b/routers/users.py
@@ -254,11 +254,11 @@ async def update_my_profile(user_id: CurrentUserId, update_data: UserUpdateReque
 
     # 동적 SET 절 생성: "nickname = %(nickname)s, profile_img = %(profile_img)s"
     set_clause = ", ".join(f"{key} = %({key})s" for key in update_fields)
-    update_fields["user_id"] = user_id
+    update_data = {**update_fields, "user_id": user_id}
 
     await cur.execute(
         f"UPDATE users SET {set_clause} WHERE id = %(user_id)s",
-        update_fields
+        update_data
     )
 
     if cur.rowcount == 0:

--- a/routers/users.py
+++ b/routers/users.py
@@ -16,7 +16,7 @@ from utils.auth import (
     hash_password, verify_password, create_access_token, create_refresh_token,
     decode_token, DUMMY_HASH, get_current_user_id
 )
-from utils.data import read_json, write_json
+from utils.database import read_json, write_json
 
 router = APIRouter(
     tags=["USERS"],

--- a/schemas/commons.py
+++ b/schemas/commons.py
@@ -49,7 +49,7 @@ Title = Annotated[
 
 Count = Annotated[int, Field(ge=0)]
 
-DbCursor = Annotated[Cursor, Depends(get_cursor)]
+CurrentCursor = Annotated[Cursor, Depends(get_cursor)]
 
 
 class Pagination(BaseModel):

--- a/schemas/commons.py
+++ b/schemas/commons.py
@@ -1,6 +1,10 @@
 from typing import Annotated
 
+from aiomysql import Cursor
+from fastapi import Depends
 from pydantic import Field, BaseModel, StringConstraints
+
+from utils.database import get_cursor
 
 UserId = Annotated[
     str,
@@ -44,6 +48,8 @@ Title = Annotated[
 ]
 
 Count = Annotated[int, Field(ge=0)]
+
+DbCursor = Annotated[Cursor, Depends(get_cursor)]
 
 
 class Pagination(BaseModel):

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -1,3 +1,4 @@
+import hashlib
 import hmac
 import logging
 from datetime import datetime, UTC, timedelta
@@ -44,6 +45,10 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
     except ValueError:
         logger.warning("Invalid hash format detected")
         return False
+
+
+def hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
 
 
 def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:

--- a/utils/database.py
+++ b/utils/database.py
@@ -43,8 +43,8 @@ async def init_pool() -> None:
         charset='utf8mb4',
         autocommit=False,
         cursorclass=aiomysql.DictCursor,
-        minsize=5,
-        maxsize=20,
+        minsize=2,
+        maxsize=10,
     )
 
 

--- a/utils/database.py
+++ b/utils/database.py
@@ -4,7 +4,6 @@ import aiomysql
 
 import json
 
-import logging
 from pathlib import Path
 from typing import Any, AsyncGenerator
 
@@ -13,8 +12,6 @@ from fastapi import HTTPException, status
 from config import settings
 
 pool: aiomysql.Pool | None = None
-
-logger = logging.getLogger(__name__)
 
 
 def get_pool() -> aiomysql.Pool:
@@ -30,9 +27,8 @@ async def get_cursor() -> AsyncGenerator[Cursor, None]:
             try:
                 yield cur
                 await conn.commit()
-            except Exception as e:
+            except Exception:
                 await conn.rollback()
-                logger.error("Failed to rollback transaction: %s", e)
                 raise
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "aiomysql"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pymysql" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/e0/302aeffe8d90853556f47f3106b89c16cc2ec2a4d269bdfd82e3f4ae12cc/aiomysql-0.3.2.tar.gz", hash = "sha256:72d15ef5cfc34c03468eb41e1b90adb9fd9347b0b589114bd23ead569a02ac1a", size = 108311, upload-time = "2025-10-22T00:15:21.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/af/aae0153c3e28712adaf462328f6c7a3c196a1c1c27b491de4377dd3e6b52/aiomysql-0.3.2-py3-none-any.whl", hash = "sha256:c82c5ba04137d7afd5c693a258bea8ead2aad77101668044143a991e04632eb2", size = 71834, upload-time = "2025-10-22T00:15:15.905Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -38,6 +50,7 @@ name = "aws13th-social-backend-gpffh20"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "aiomysql" },
     { name = "bcrypt" },
     { name = "fastapi", extra = ["standard"] },
     { name = "pydantic", extra = ["email"] },
@@ -53,6 +66,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiomysql", specifier = ">=0.3.2" },
     { name = "bcrypt", specifier = ">=4.0.0,<5.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.128.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
@@ -631,6 +645,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+]
+
+[[package]]
+name = "pymysql"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/ae/1fe3fcd9f959efa0ebe200b8de88b5a5ce3e767e38c7ac32fb179f16a388/pymysql-1.1.2.tar.gz", hash = "sha256:4961d3e165614ae65014e361811a724e2044ad3ea3739de9903ae7c21f539f03", size = 48258, upload-time = "2025-08-24T12:55:55.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/4c/ad33b92b9864cbde84f259d5df035a6447f91891f5be77788e2a3892bce3/pymysql-1.1.2-py3-none-any.whl", hash = "sha256:e6b1d89711dd51f8f74b1631fe08f039e7d76cf67a42a323d3178f0f25762ed9", size = 45300, upload-time = "2025-08-24T12:55:53.394Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- MariaDB 연결 구현 (aiomysql 드라이버 사용)
- users 라우터의 모든 API를 JSON 파일 기반에서 DB 기반으로 마이그레이션
- FastAPI Depends를 활용한 DB cursor 의존성 주입 패턴 적용
- Refresh Token Rotation 구현으로 토큰 탈취 대응 강화

## 변경 이유
<!-- 왜 이 변경이 필요한지 설명해주세요 -->
- JSON 파일 기반 데이터 저장의 한계 (동시성, 확장성, 데이터 무결성)
- 실무 수준의 DB 연동 필요
- Refresh Token 탈취 시 무한 Access Token 발급 가능한 보안 취약점 해결


## 체크리스트
- [x] 코드 변경사항이 제대로 동작함을 확인했습니다
- [ ] 새로운 기능에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 따랐습니다
- [x] Breaking changes가 있다면 명시했습니다


## 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- DB 스키마 변경 필요:
  ```sql
  CREATE TABLE users (
      id VARCHAR(50) PRIMARY KEY,
      email VARCHAR(255) NOT NULL UNIQUE,
      nickname VARCHAR(10) NOT NULL,
      password VARCHAR(255) NOT NULL,
      profile_img VARCHAR(500),
      refresh_token VARCHAR(500),
      created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
  );


## 🚨 Breaking Changes
<!-- 
Breaking Changes란? 
기존에 동작하던 코드나 API가 이번 변경으로 인해 더 이상 작동하지 않게 되는 변경사항을 의미합니다.
예: 함수 이름 변경, 파라미터 변경, API 엔드포인트 변경 등
해당사항이 없다면 체크박스를 해제된 상태로 두시면 됩니다.
-->
- [x] 이 PR은 Breaking Changes를 포함합니다
<!-- Breaking Changes가 있다면 아래에 구체적으로 설명해주세요 -->
| 항목 | 변경 내용 |
|-----|----------|
| `POST /auth/logout` | 인증 필요 (Access Token 필수) |
| `POST /auth/tokens/refresh` | 응답에 새 refresh_token이 쿠키로 설정됨 |
| `utils/data.py` → `utils/database.py` | 파일명 변경 - 기존 import 수정 필요 |
## 코드리뷰 포인트
<!-- 리뷰어가 특히 집중해서 봐주길 원하는 부분이 있다면 작성해주세요 -->
- Refresh Token Rotation 로직 (탈취 감지시 토큰 무효화)
- DbCursor 의존성 주입 타입 정의
- get_cursor generator 함수